### PR TITLE
fix: Critical event listener memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+node_modules/*

--- a/user_auto.js
+++ b/user_auto.js
@@ -1057,7 +1057,12 @@ const aUtils = {
             try {
                 var file = new air.File();
                 file.browseForOpen("Select a Template");
-                file.addEventListener(air.Event.SELECT, callback);
+                // Use self-removing handler to prevent memory leak
+                var selectHandler = function(event) {
+                    file.removeEventListener(air.Event.SELECT, selectHandler);
+                    callback(event);
+                };
+                file.addEventListener(air.Event.SELECT, selectHandler);
             } catch (e) { }
         },
         SaveTemplate: function (template) {
@@ -1485,7 +1490,7 @@ const aUI = {
                 } else {
                     if (existingGridPosMenu) {
                         window.nativeWindow.menu.removeItem(existingGridPosMenu);
-                        window.nativeWindow.stage.removeEventListener(64, auto.generateGrid);
+                        window.nativeWindow.stage.removeEventListener("click", auto.generateGrid);
                     }
                 }
                 if (!menu.nativeMenu.getItemByName("Automation").submenu)
@@ -2439,14 +2444,17 @@ const aUI = {
                         var txtFilter = new air.FileFilter("Template", "*.*");
                         var root = new air.File();
                         root.browseForOpenMultiple("Open", new window.runtime.Array(txtFilter));
-                        root.addEventListener(window.runtime.flash.events.FileListEvent.SELECT_MULTIPLE, function (event) {
+                        // Use self-removing handler to prevent memory leak
+                        var selectHandler = function (event) {
+                            root.removeEventListener(window.runtime.flash.events.FileListEvent.SELECT_MULTIPLE, selectHandler);
                             event.files.forEach(function (file) {
                                 const data = aUtils.file.Read(file.nativePath);
                                 if (!data) return alert('Invalid file');
                                 aWindow.steps.push({ name: 'AdventureTemplate', file: file.nativePath, data: data });
                             });
                             aUI.modals.adventure.TM_UpdateView();
-                        });
+                        };
+                        root.addEventListener(window.runtime.flash.events.FileListEvent.SELECT_MULTIPLE, selectHandler);
                     } else {
                         const isNotVenture = aAdventure.data.getAdventureType($("#aTemplate_AdventureSelect").val()) !== "Venture";
                         if (this.name === 'CollectPickups' && isNotVenture)


### PR DESCRIPTION
## Summary
- Fix removeEventListener type mismatch (64 vs "click") that prevented cleanup
- Make file SELECT and SELECT_MULTIPLE event handlers self-removing
- Add node_modules to gitignore

## Test plan
- [ ] Verify menu removal properly cleans up click listener
- [ ] Test file browser dialogs don't accumulate listeners
- [ ] Confirm no regression in file selection functionality